### PR TITLE
uses fully continuous middle skip instead of pipe

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,7 +170,7 @@ impl GlyphPalette {
             last_item: "└",
             item_indent: "── ",
 
-            middle_skip: "|",
+            middle_skip: "│",
             last_skip: " ",
             skip_indent: "   ",
         }
@@ -229,7 +229,7 @@ mod tests {
             format!("{}", tree),
             r#"foo
 ├── hello
-|   world
+│   world
 └── goodbye
     world
 "#


### PR DESCRIPTION
The pipe character is not fully continuous. I guess it depends on the font you're using -- with my font I immediately recognized that there were gaps in longer middle-skip sections. In the diff on GitHub I can't really see the difference between the two characters :smile: (I've copy-pasted the fully continuous one from one of my TUIs). 